### PR TITLE
✨ Add an `..` alias for more straightforward navigation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+
+orbs:
+  shellcheck: circleci/shellcheck@3.1.2
+
+workflows:
+  build:
+    jobs:
+      - shellcheck/check:
+          pattern: "aliases.local"

--- a/aliases.local
+++ b/aliases.local
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Easier navigation: ..
+alias ..="cd .."


### PR DESCRIPTION
Before, we would have to use four keystrokes to move up a directory in the terminal. We wasted so much unnecessary time. We added an `..` alias to halve the keystrokes and gain productivity.
