### PR TITLE
🗑️ Drop the `..` navigation alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-# Easier navigation: .., ..., ....
-alias ..="cd .."
+# Easier navigation: ..., ....
 alias ...="cd ../.."
 alias ....="cd ../../.."


### PR DESCRIPTION
Before, we introduced a `..` alias for quicker navigation. It turned out that this change was unnecessary. thoughtbot's dotfiles include `setopt autocd` in its Z shell configuration. We got this navigation alias for free. We dropped the `..` navigation alias.
