### PR TITLE
✨ Add a Dropbox alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -2,3 +2,6 @@
 
 # Easier navigation: .....
 alias .....="cd ../../../.."
+
+# Shortcuts
+alias d="cd ~/Library/CloudStorage/Dropbox"


### PR DESCRIPTION
Before, it was a challenge to remember how to navigate to the Dropbox directory. We wasted time trying to figure out the correct path. We added a simple `d` alias to simplify the process.
