### PR TITLE
🗑️ Add a Downloads alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -5,3 +5,4 @@ alias .....="cd ../../../.."
 
 # Shortcuts
 alias d="cd ~/Library/CloudStorage/Dropbox"
+alias dl="cd ~/Downloads"


### PR DESCRIPTION
Before, it was a challenge to remember how to navigate to the Downloads directory. We wasted time trying to figure out the correct path. We added a simple `dl` alias to simplify the process.
