### PR TITLE
✨ Add an `-` alias for quicker navigation

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Easier navigation: -
+alias -- -="cd -"
+
 # Shortcuts
 alias d="cd ~/Library/CloudStorage/Dropbox"
 alias dl="cd ~/Downloads"


### PR DESCRIPTION
Before, we would have to use four keystrokes to move to the previous directory in the terminal. We wasted so much unnecessary time. We added an `-` alias to reduce the keystrokes and gain productivity.
