### PR TITLE
✨ Add colours when listing directory contents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,4 +7,4 @@ workflows:
   build:
     jobs:
       - shellcheck/check:
-          pattern: "aliases.local"
+          pattern: "{aliases|zshrc}.local"

--- a/zshrc.local
+++ b/zshrc.local
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+
+export LSCOLORS="BxBxhxDxfxhxhxhxhxcxcx"
+
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools
@@ -6,9 +10,12 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools
 
 # load custom executable functions
 for function in ~/.zsh/lib/*; do
-  source $function
+  # shellcheck source=/dev/null
+  source "$function"
 done
 
 export PATH="/usr/local/opt/terraform@0.12/bin:$PATH"
 export PATH="$HOME/.bin:$PATH"
+
+# shellcheck source=/dev/null
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh


### PR DESCRIPTION
Before, we used the terminal's default settings when listing directory contents. We wanted to add our preferred colours. We added an `LSCOLORS` definition to customise the output.
