### PR TITLE
✨ Add a listing directory alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -8,3 +8,6 @@ alias d="cd ~/Library/CloudStorage/Dropbox"
 alias dl="cd ~/Downloads"
 alias dt="cd ~/Desktop"
 alias p="cd ~/Developer"
+
+# List all files in long format
+alias l="ls -lF"


### PR DESCRIPTION
Before, we loved listing files in the long format using `ls -lF`. We hated having to type all those characters, though. We added an `l` alias to reduce typing and increase productivity.
