### PR TITLE
🗑️ Drop the `-` navigation alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Easier navigation: -
-alias -- -="cd -"
-
 # Shortcuts
 alias d="cd ~/Library/CloudStorage/Dropbox"
 alias dl="cd ~/Downloads"


### PR DESCRIPTION
Before, we had added an `-` alias for quicker navigation. We have since upstreamed this change into thoughtbot's dotfiles. This alias was no longer necessary in this repository. We dropped the alias.
