### PR TITLE
✨ Add a listing directory alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -8,3 +8,6 @@ alias p="cd ~/Developer"
 
 # List all files in long format
 alias l="ls -lF"
+
+# List all files colorized in long format, excluding . and ..
+alias la="ls -lAF"


### PR DESCRIPTION
Before, we loved listing all files in the long format using `ls -lAF`. We hated having to type all those characters, though. We added an `la` alias to reduce typing and increase productivity.
