### PR TITLE
✨ Add a listing directory alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -11,3 +11,6 @@ alias l="ls -lF"
 
 # List all files colorized in long format, excluding . and ..
 alias la="ls -lAF"
+
+# List only directories
+alias lsd="ls -lF | ag --nocolor '^d'"


### PR DESCRIPTION
Before, we loved listing only directories in the long format using `ls -lF | ag --nocolor '^d'`. We hated having to type all those characters, though. We added an `lsd` alias to reduce typing and increase productivity.
