### PR TITLE
✨ Add a sudo alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -14,3 +14,6 @@ alias la="ls -lAF"
 
 # List only directories
 alias lsd="ls -lF | ag --nocolor '^d'"
+
+# Enable aliases to be sudo’ed
+alias sudo='sudo '


### PR DESCRIPTION
Before, there was no way to run aliases using sudo. Instead, we had to run the long command prefixed with `sudo`. We added a `sudo` alias to allow us to sudo other aliases.
