### PR TITLE
✨ Add an alias to get the week number

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -17,3 +17,6 @@ alias lsd="ls -lF | ag --nocolor '^d'"
 
 # Enable aliases to be sudo’ed
 alias sudo='sudo '
+
+# Get week number
+alias week='date +%V'


### PR DESCRIPTION
Before, when we wanted to get the week number from the terminal, we had to remember the correct format code. We need help remembering things and love to think less. We added a `week` alias to reduce the mental overhead.
