### PR TITLE
✨ Add an alias to get software updates

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -20,3 +20,6 @@ alias sudo='sudo '
 
 # Get week number
 alias week='date +%V'
+
+# Get macOS Software Updates, and update installed Ruby gems, Homebrew, npm, and their installed packages
+alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup; npm install npm -g; npm update -g; sudo gem update --system; sudo gem update; sudo gem cleanup'


### PR DESCRIPTION
Before, when we wanted to get various software updates, we had to run several different commands. We need help remembering things and love to think less. We added an `update` alias to reduce the mental overhead.
