### PR TITLE
✨ Add an alias to get our IP address

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -23,3 +23,6 @@ alias week='date +%V'
 
 # Get macOS Software Updates, and update installed Ruby gems, Homebrew, npm, and their installed packages
 alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup; npm install npm -g; npm update -g; sudo gem update --system; sudo gem update; sudo gem cleanup'
+
+# IP addresses
+alias ip="dig +short myip.opendns.com @resolver1.opendns.com"


### PR DESCRIPTION
Before, when we wanted to get our IP address from the terminal, we had to remember the correct incantation. We need help remembering things and love to think less. We added a `ip` alias to reduce the mental overhead.
