### PR TITLE
✨ Add an alias to get our local IP address

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -26,3 +26,4 @@ alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup
 
 # IP addresses
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
+alias localip="ipconfig getifaddr en0"


### PR DESCRIPTION
Before, when we wanted to get our local IP address from the terminal, we had to remember the correct incantation. We need help remembering things and love to think less. We added a `localip` alias to reduce the mental overhead.
