### PR TITLE
✨ Add an alias to list our IP addresses

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -27,3 +27,4 @@ alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup
 # IP addresses
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
 alias localip="ipconfig getifaddr en0"
+alias ips="ifconfig -a | ag -o 'inet6? (addr:)?\s?((([0-9]+.){3}[0-9]+)|[a-fA-F0-9:]+)' | awk '{ sub(/inet6? (addr:)? ?/, \"\"); print }'"


### PR DESCRIPTION
Before, it was a challenge to list the IP addresses of all our local network interfaces. We would need knowledge of various UNIX commands and how to pipe them together to do so. We added an `ips` alias to reduce the need to look up anything in the future.
