### PR TITLE
✨ Add an `ifactive` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -28,3 +28,6 @@ alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
 alias localip="ipconfig getifaddr en0"
 alias ips="ifconfig -a | ag -o 'inet6? (addr:)?\s?((([0-9]+.){3}[0-9]+)|[a-fA-F0-9:]+)' | awk '{ sub(/inet6? (addr:)? ?/, \"\"); print }'"
+
+# Show active network interfaces
+alias ifactive="ifconfig | pcregrep -M -o '^[^\t:]+:([^\n]|\n\t)*status: active'"


### PR DESCRIPTION
Before, to identify active interfaces, we would have to parse the output from `ifconfig`. This command returned a massive wall of text. It was a challenge to parse and easy to miss vital information. We added an `ifactive` alias to do the parsing for us.

- [StackExchange](https://unix.stackexchange.com/a/108048)
