### PR TITLE
✨ Add a `flush` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -31,3 +31,6 @@ alias ips="ifconfig -a | ag -o 'inet6? (addr:)?\s?((([0-9]+.){3}[0-9]+)|[a-fA-F0
 
 # Show active network interfaces
 alias ifactive="ifconfig | pcregrep -M -o '^[^\t:]+:([^\n]|\n\t)*status: active'"
+
+# Flush Directory Service cache
+alias flush="dscacheutil -flushcache && killall -HUP mDNSResponder"


### PR DESCRIPTION
Before, we would sometimes incur network issues on our local machines. Remembering how to flush the cache would take searching online and hoping to find the right post. We wanted to reduce the need to remember anything and remove any chance of human error. We added a `flush` alias to make our lives more manageable.
