### PR TITLE
✨ Add a `lscleanup` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -34,3 +34,6 @@ alias ifactive="ifconfig | pcregrep -M -o '^[^\t:]+:([^\n]|\n\t)*status: active'
 
 # Flush Directory Service cache
 alias flush="dscacheutil -flushcache && killall -HUP mDNSResponder"
+
+# Clean up LaunchServices to remove duplicates in the “Open With” menu
+alias lscleanup="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -kill -r -domain local -domain system -domain user && killall Finder"


### PR DESCRIPTION
Before, we would sometimes get duplicate items in macOS's "Open with…" menu. These duplications were unnecessary and got in the way. We added a `lscleanup` alias to remove the duplicates.
