### PR TITLE
✨ Add a `hd` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -37,3 +37,6 @@ alias flush="dscacheutil -flushcache && killall -HUP mDNSResponder"
 
 # Clean up LaunchServices to remove duplicates in the “Open With” menu
 alias lscleanup="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -kill -r -domain local -domain system -domain user && killall Finder"
+
+# Canonical hex dump; some systems have this symlinked
+command -v hd > /dev/null || alias hd="hexdump -C"


### PR DESCRIPTION
Before, we must remember the correct command to perform a canonical hexdump. This required looking at manpages or searching for things online. This was a waste of time and opened us up to human error. We added a simple `hd` alias to remove all that hassle.
