### PR TITLE
✨ Add a `md5sum` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -40,3 +40,6 @@ alias lscleanup="/System/Library/Frameworks/CoreServices.framework/Frameworks/La
 
 # Canonical hex dump; some systems have this symlinked
 command -v hd > /dev/null || alias hd="hexdump -C"
+
+# macOS has no `md5sum`, so use `md5` as a fallback
+command -v md5sum > /dev/null || alias md5sum="md5"


### PR DESCRIPTION
Before, we had to remember if macOS uses `md5sum` of `md5`. This required us to use more brainpower than needed. We added a `md5sum` alias to make our lives simpler.
