### PR TITLE
✨ Add a `sha1sum` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -43,3 +43,6 @@ command -v hd > /dev/null || alias hd="hexdump -C"
 
 # macOS has no `md5sum`, so use `md5` as a fallback
 command -v md5sum > /dev/null || alias md5sum="md5"
+
+# macOS has no `sha1sum`, so use `shasum` as a fallback
+command -v sha1sum > /dev/null || alias sha1sum="shasum"


### PR DESCRIPTION
Before, we had to remember if macOS uses `sha1sum` or `shasum`. This required us to use more brainpower than needed. We added a `sha1sum` alias to make our lives simpler.
