### PR TITLE
✨ Add a `jsc` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -46,3 +46,8 @@ command -v md5sum > /dev/null || alias md5sum="md5"
 
 # macOS has no `sha1sum`, so use `shasum` as a fallback
 command -v sha1sum > /dev/null || alias sha1sum="shasum"
+
+# JavaScriptCore REPL
+jscbin="/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Helpers/jsc";
+[ -e "${jscbin}" ] && alias jsc="${jscbin}";
+unset jscbin;


### PR DESCRIPTION
Before, it was challenging to run a JavaScript REPL on our local machines. We would have to install Node.js or remember the precise, hidden path of the JavaScript console. We added a `jsc` alias to make the hidden console more accessible.
