### PR TITLE
🗑️ Drop the listing and upgrading of outdated apps

### DIFF
--- a/zsh/lib/uatt.zsh
+++ b/zsh/lib/uatt.zsh
@@ -14,8 +14,5 @@ uatt() {
   asdf update
   asdf plugin-update --all
   echo $SEPERATOR
-  mas outdated
-  mas upgrade
-  echo $SEPERATOR
   waiter 5
 }


### PR DESCRIPTION
Before, we listed and upgraded outdated Mac App Store Apps. There were too many bugs in the upgrade script that made this unhelpful. We also got this functionality from CleanMyMac. We dropped the listing and upgrading of outdated apps from our update script.
