### PR TITLE
🗑️ Drop updating asdf to the latest release

### DIFF
--- a/zsh/lib/uatt.zsh
+++ b/zsh/lib/uatt.zsh
@@ -11,7 +11,6 @@ uatt() {
   rcup
   echo "Dotfiles up-to-date"
   echo $SEPERATOR
-  asdf update
   asdf plugin-update --all
   echo $SEPERATOR
   waiter 5


### PR DESCRIPTION
Before, we would update asdf by running `asdf update`. The command started to return the following message instead of running.

> Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.

We dropped updating asdf to the latest release because Homebrew will do this for us.
