### PR TITLE
🗑️ Drop vim-hardtime running in every buffer

### DIFF
--- a/vimrc.local
+++ b/vimrc.local
@@ -8,7 +8,6 @@ let g:ale_fixers = {
 \  'ruby': ['standardrb'],
 \}
 let g:ale_fix_on_save = 1
-let g:hardtime_default_on = 1
 
 " Set up the PaperColor colour scheme. We have to set the terminal colours to
 " 256 because it looked wrong with only 16 colours. This is likely related to


### PR DESCRIPTION
Before, we had vim-runtime running in every buffer by default. Recently, this caused Vim to raise an "E109: Missing ':' after '?'" error when staging and unstaging files in vim-fugitive. We dropped vim-hardtime running in every buffer until a fix is available.
