### PR TITLE
🗑️ Drop the custom tmux statuses

### DIFF
--- a/tmux.conf.local
+++ b/tmux.conf.local
@@ -27,6 +27,3 @@ if-shell '[[ $(uname -s) = Darwin ]]' {
 }
 
 if-shell 'test -e /usr/bin/zsh' 'set -g default-shell /usr/bin/zsh'
-
-set-option -g status-left ""
-set-option -g status-right ""


### PR DESCRIPTION
Before, we set some custom tmux statuses to help with the compatibility of a plugin. We no longer use that plugin, so the custom statuses are unnecessary. We dropped them from our tmux config.
