### PR TITLE
🗑️ Drop Xcode from the Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -46,4 +46,3 @@ mas "1Blocker", id: 1365531024
 mas "1Password for Safari", id: 1569813296
 mas "Bear", id: 1091189122
 mas "Things", id: 904280696
-mas "Xcode", id: 497799835


### PR DESCRIPTION
Before, we used Xcode to help us debug React Native applications. It has been a while since we did any React Native development. We dropped Xcode from the Brewfile.
