### PR TITLE
✨ Add UTM to the Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -41,6 +41,7 @@ cask "microsoft-teams"
 cask "rectangle"
 cask "spotify"
 cask "tuple"
+cask "utm"
 cask "zoom"
 mas "1Blocker", id: 1365531024
 mas "1Password for Safari", id: 1569813296


### PR DESCRIPTION
Before, we could not test our changes in a fresh installation. We would have to wait until we built a new machine to have complete confidence. We added UTM to the Brewfile to allow us to test the scripts.
