### PR TITLE
✨ Add a `c` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -51,3 +51,6 @@ command -v sha1sum > /dev/null || alias sha1sum="shasum"
 jscbin="/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Helpers/jsc";
 [ -e "${jscbin}" ] && alias jsc="${jscbin}";
 unset jscbin;
+
+# Trim new lines and copy to clipboard
+alias c="tr -d '\n' | pbcopy"


### PR DESCRIPTION
Before, we would want to trim new lines from some text before copying it. This would involve us remembering the correct bash command. We added a `c` alias to remove this necessity.
