### PR TITLE
🗑️ Drop unnecessary Homebrew taps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,8 +1,6 @@
 tap "1password/tap"
 tap "heroku/brew"
 tap "homebrew/bundle"
-tap "homebrew/cask"
-tap "homebrew/core"
 tap "homebrew/services"
 tap "mas-cli/tap"
 tap "thoughtbot/formulae"


### PR DESCRIPTION
Before, we had to include Homebrew's `cask` and `core` taps for some of our packages. Homebrew has now upstreamed these into the core application. It is now unnecessary to include these taps so we can drop them.
