### PR TITLE
✨ Add a `cleanup` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -54,3 +54,6 @@ unset jscbin;
 
 # Trim new lines and copy to clipboard
 alias c="tr -d '\n' | pbcopy"
+
+# Recursively delete `.DS_Store` files
+alias cleanup="find . -type f -name '*.DS_Store' -ls -delete"


### PR DESCRIPTION
Before, we would often find `.DS_Store` files. They did nothing but clutter up the filesystem. We added a `cleanup` alias to delete any of these files.
