### PR TITLE
✨ Add an `emptytrash` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -57,3 +57,9 @@ alias c="tr -d '\n' | pbcopy"
 
 # Recursively delete `.DS_Store` files
 alias cleanup="find . -type f -name '*.DS_Store' -ls -delete"
+
+# Empty the Trash on all mounted volumes and the main HDD.
+# Also, clear Apple’s System Logs to improve shell startup speed.
+# Finally, clear download history from quarantine.
+# https://www.macgasm.net/news/tips/good-morning-your-mac-keeps-a-log-of-all-your-downloads/
+alias emptytrash="sudo rm -rfv /Volumes/*/.Trashes; sudo rm -rfv ~/.Trash; sudo rm -rfv /private/var/log/asl/*.asl; sqlite3 ~/Library/Preferences/com.apple.LaunchServices.QuarantineEventsV* 'delete from LSQuarantineEvent'"


### PR DESCRIPTION
Before, we wanted to clear a bunch of stuff from our machines. All the different places were a challenge to remember. We added an `emptytrash` alias, so we only have to remember one thing.
