### PR TITLE
✨ Add "show/hide" aliases

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -63,3 +63,7 @@ alias cleanup="find . -type f -name '*.DS_Store' -ls -delete"
 # Finally, clear download history from quarantine.
 # https://www.macgasm.net/news/tips/good-morning-your-mac-keeps-a-log-of-all-your-downloads/
 alias emptytrash="sudo rm -rfv /Volumes/*/.Trashes; sudo rm -rfv ~/.Trash; sudo rm -rfv /private/var/log/asl/*.asl; sqlite3 ~/Library/Preferences/com.apple.LaunchServices.QuarantineEventsV* 'delete from LSQuarantineEvent'"
+
+# Show/hide hidden files in Finder
+alias show="defaults write com.apple.finder AppleShowAllFiles -bool true && killall Finder"
+alias hide="defaults write com.apple.finder AppleShowAllFiles -bool false && killall Finder"


### PR DESCRIPTION
Before, it was challenging to show and hide hidden files in Finder. Most of the time, we would have to open up Terminal. We added `show` and `hide` aliases to toggle visibility.
