### PR TITLE
✨ Add "hide/show Desktop" aliases

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -67,3 +67,7 @@ alias emptytrash="sudo rm -rfv /Volumes/*/.Trashes; sudo rm -rfv ~/.Trash; sudo 
 # Show/hide hidden files in Finder
 alias show="defaults write com.apple.finder AppleShowAllFiles -bool true && killall Finder"
 alias hide="defaults write com.apple.finder AppleShowAllFiles -bool false && killall Finder"
+
+# Hide/show all desktop icons (useful when presenting)
+alias hidedesktop="defaults write com.apple.finder CreateDesktop -bool false && killall Finder"
+alias showdesktop="defaults write com.apple.finder CreateDesktop -bool true && killall Finder"


### PR DESCRIPTION
Before, when we presented from our machines, the icons on our Desktop always showed. There were occasions when we wanted to avoid this. Hiding and showing the icons is non-trivial. We added two aliases to simplify the process.
