### PR TITLE
✨ Add a `urlencode` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -71,3 +71,6 @@ alias hide="defaults write com.apple.finder AppleShowAllFiles -bool false && kil
 # Hide/show all desktop icons (useful when presenting)
 alias hidedesktop="defaults write com.apple.finder CreateDesktop -bool false && killall Finder"
 alias showdesktop="defaults write com.apple.finder CreateDesktop -bool true && killall Finder"
+
+# URL-encode strings
+alias urlencode='ruby -e "require \"uri\"; puts URI.encode_www_form_component(ARGF.read)"'


### PR DESCRIPTION
Before, if we wanted to URL encode a string, we would fire up a web browser and find a site to do that for us. This was time-consuming when we could run a little Ruby script on our local machines. We added a `urlencode` alias to run a one-line Ruby script to URL encode a string.
