### PR TITLE
✨ Add a `mergepdf` alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -74,3 +74,7 @@ alias showdesktop="defaults write com.apple.finder CreateDesktop -bool true && k
 
 # URL-encode strings
 alias urlencode='ruby -e "require \"uri\"; puts URI.encode_www_form_component(ARGF.read)"'
+
+# Merge PDF files, preserving hyperlinks
+# Usage: `mergepdf input{1,2,3}.pdf`
+alias mergepdf='gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=_merged.pdf'


### PR DESCRIPTION
Before, if we wanted to merge any PDFs, we would have to launch Preview and do a bunch of drag and dropping. This was laborious and involved us using the mouse. Since Mac OS X Tiger, Apple included a script to do this for us. We added a `mergepdf` alias to merge PDFs from the command line.
