### PR TITLE
✨ Add Docker

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -33,6 +33,10 @@ cask "1password/tap/1password-cli"
 cask "alfred"
 cask "cleanmymac"
 cask "dash"
+
+# We use Docker to run Elasticsearch for `hub`.
+cask "docker"
+
 cask "dropbox"
 cask "google-chrome"
 cask "gpg-suite-no-mail"


### PR DESCRIPTION
Before, we used Docker on a thoughtbot project. Because of our `uatt` script, we uninstalled and installed Docker every day. This was time-consuming and unnecessary. We added Docker to our Brewfile, so it will remain installed until we say so.
