### PR TITLE
✨ Add Spotlight toggles

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -78,3 +78,8 @@ alias urlencode='ruby -e "require \"uri\"; puts URI.encode_www_form_component(AR
 # Merge PDF files, preserving hyperlinks
 # Usage: `mergepdf input{1,2,3}.pdf`
 alias mergepdf='gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=_merged.pdf'
+
+# Disable Spotlight
+alias spotoff="sudo mdutil -a -i off"
+# Enable Spotlight
+alias spoton="sudo mdutil -a -i on"


### PR DESCRIPTION
Before, we sometimes wanted to toggle Spotlight indexing on our Mac. This may have been for performance, privacy, or troubleshooting. Remembering the incantation to do so was unnecessary. We added two aliases to disable and enable Spotlight indexing.
