### PR TITLE
✨ Add `plistbuddy`

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -83,3 +83,6 @@ alias mergepdf='gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=_merged.p
 alias spotoff="sudo mdutil -a -i off"
 # Enable Spotlight
 alias spoton="sudo mdutil -a -i on"
+
+# PlistBuddy alias, because sometimes `defaults` just doesn’t cut it
+alias plistbuddy="/usr/libexec/PlistBuddy"


### PR DESCRIPTION
Editing plist files was challenging before. macOS contains a tool called PlistBuddy to aid with this exercise, but the tool is in a non-obvious place. We added a `plistbuddy` alias to make the tool more accessible.
