### PR TITLE
✨ Add `airport`

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -86,3 +86,6 @@ alias spoton="sudo mdutil -a -i on"
 
 # PlistBuddy alias, because sometimes `defaults` just doesn’t cut it
 alias plistbuddy="/usr/libexec/PlistBuddy"
+
+# Airport CLI alias
+alias airport='/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport'


### PR DESCRIPTION
Before, we would use Apple's Wireless Diagnostics tool to help with networking issues. The tool's UI could be more intuitive and are a hassle. macOS has a hidden `airport` CLI that gives us access to the same information. Unfortunately, Apple hid the executable somewhere in the internals of macOS. We added an `airport` alias for easier access.
