### PR TITLE
✨ Add `map`

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -89,3 +89,8 @@ alias plistbuddy="/usr/libexec/PlistBuddy"
 
 # Airport CLI alias
 alias airport='/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport'
+
+# Intuitive map function
+# For example, to list all directories that contain a certain file:
+# find . -name .gitattributes | map dirname
+alias map="xargs -n1"


### PR DESCRIPTION
Before, when we wanted to loop through a command, we would have to remember the correct `xargs` call. This was unintuitive and unnecessary. To make the command more memorable, we added a `map` alias.
