### PR TITLE
✨ Add aliases for all the HTTP verbs

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -94,3 +94,8 @@ alias airport='/System/Library/PrivateFrameworks/Apple80211.framework/Versions/C
 # For example, to list all directories that contain a certain file:
 # find . -name .gitattributes | map dirname
 alias map="xargs -n1"
+
+# One of @janmoesen’s ProTip™s
+for method in GET HEAD POST PUT DELETE TRACE OPTIONS; do
+  alias "${method}"="lwp-request -m '${method}'"
+done


### PR DESCRIPTION
Before, if we wanted to send HTTP requests from the command line, we'd have to remember the syntax. This was laborious and required some unnecessary reading of the documentation. We added aliases for all the HTTP verbs to make the commands more memorable.
