### PR TITLE
✨ Add volume aliases

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -99,3 +99,7 @@ alias map="xargs -n1"
 for method in GET HEAD POST PUT DELETE TRACE OPTIONS; do
   alias "${method}"="lwp-request -m '${method}'"
 done
+
+# Stuff I never really use but cannot delete either because of http://xkcd.com/530/
+alias stfu="osascript -e 'set volume output muted true'"
+alias pumpitup="osascript -e 'set volume output volume 50'"


### PR DESCRIPTION
Before, we would have to hunt down the mute switch on our keyboard to change our Mac's volume. This takes little effort, but we want our top volume to be 50%. We're getting old; finding the middle takes some squinting and leaning in nowadays. We added some whimsical volume aliases to make our lives more enjoyable.
