### PR TITLE
✨ Add `chromekill`

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -103,3 +103,7 @@ done
 # Stuff I never really use but cannot delete either because of http://xkcd.com/530/
 alias stfu="osascript -e 'set volume output muted true'"
 alias pumpitup="osascript -e 'set volume output volume 50'"
+
+# Kill all the tabs in Chrome to free up memory
+# [C] explained: http://www.commandlinefu.com/commands/view/402/exclude-grep-from-your-grepped-output-of-ps-alias-included-in-description
+alias chromekill="ps ux | grep '[C]hrome Helper --type=renderer' | grep -v extension-process | tr -s ' ' | cut -d ' ' -f2 | xargs kill"


### PR DESCRIPTION
Before, Chrome would leave running processes after running a Rails test suite. We had to open Activity Monitor to find and kill the offending processes. What a waste of time! We added the `chromekill` alias to do the same with one command.
