### PR TITLE
✨ Add Notion

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -42,6 +42,10 @@ cask "docker"
 cask "dropbox"
 cask "google-chrome"
 cask "gpg-suite-no-mail"
+
+# We use Notion for client documentation and task management.
+cask "notion"
+
 cask "rectangle"
 cask "spotify"
 cask "tuple"


### PR DESCRIPTION
Before, we tried to use Notion's web interface to stay on top of our client's documentation and task management. Because of the client's email setup, it was challenging to stay on top of notifications. We added the Notion macOS app to help.
