### PR TITLE
✨ Add a "reload" alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -107,3 +107,6 @@ alias pumpitup="osascript -e 'set volume output volume 50'"
 # Kill all the tabs in Chrome to free up memory
 # [C] explained: http://www.commandlinefu.com/commands/view/402/exclude-grep-from-your-grepped-output-of-ps-alias-included-in-description
 alias chromekill="ps ux | grep '[C]hrome Helper --type=renderer' | grep -v extension-process | tr -s ' ' | cut -d ' ' -f2 | xargs kill"
+
+# Reload the shell (i.e. invoke as a login shell)
+alias reload="exec ${SHELL} -l"


### PR DESCRIPTION
Before, there was no quick way to reload our shell configurations. We would have to close and reopen our terminal applications. We added a "reload" alias to apply those changes without logging out and back in.
