### PR TITLE
✨ Add case-insensitive globbing in zshrc.local

### DIFF
--- a/zshrc.local
+++ b/zshrc.local
@@ -2,6 +2,9 @@
 
 export LSCOLORS="BxBxhxDxfxhxhxhxhxcxcx"
 
+# Case-insensitive globbing (used in pathname expansion)
+setopt nocaseglob;
+
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools


### PR DESCRIPTION
This change sets the nocaseglob option in zshrc.local to enable case-insensitive pathname expansion in zsh. This is necessary to ensure consistent behavior across different environments, particularly when users expect case-insensitive file matching similar to what they may experience in bash.

By adding this option, we address issues where scripts and commands might fail or behave unexpectedly due to case sensitivity in filename matching. This improves user experience and reduces potential errors.

No negative side effects are expected from this change.
