### PR TITLE
🛠️ Make `laptop.local` update Homebrew

### DIFF
--- a/laptop.local
+++ b/laptop.local
@@ -1,1 +1,3 @@
 #!/bin/sh
+
+brew update


### PR DESCRIPTION
Before, we never checked to see if we used the latest version of Homebrew. This could lead us to miss out on the latest formulae. We made `laptop.local` update Homebrew as its first step.
