### PR TITLE
Drop GitHub Copilot

### DIFF
--- a/vimrc.bundles.local
+++ b/vimrc.bundles.local
@@ -2,4 +2,3 @@
 Plug 'NLKNguyen/papercolor-theme'
 
 Plug 'takac/vim-hardtime'
-Plug 'github/copilot.vim'


### PR DESCRIPTION
We used the GitHub Copilot Vim plugin to suggest code in real-time. But, it got in the way and proved more distracting than helpful, so we dropped it from our Vim bundles.
