### PR TITLE
🔧 Make the installer authenticate gh

### DIFF
--- a/laptop.local
+++ b/laptop.local
@@ -45,3 +45,7 @@ EOF
 . "$HOME/.install/neovim.sh"
 . "$HOME/.install/nodenv.sh"
 . "$HOME/.install/ruby.sh"
+
+if ! gh auth status > /dev/null 2>&1; then
+  gh auth login
+fi


### PR DESCRIPTION
Before, we had to run the script to authenticate ourselves in `gh`. It is easy to forget to run this command. Instead, we made the installer run this command at the end of the setup. We also ensured that the command was idempotent.
